### PR TITLE
chore: bump cookiecutter-scverse template to v0.7.0

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,7 +1,7 @@
 {
   "template": "https://github.com/scverse/cookiecutter-scverse",
-  "commit": "d383d94fadff9e4e6fdb59d77c68cb900d7cedec",
-  "checkout": "v0.6.0",
+  "commit": "6ff5b92b5d44ea6d8a88e47538475718d467db95",
+  "checkout": "v0.7.0",
   "context": {
     "cookiecutter": {
       "project_name": "scembed",
@@ -36,7 +36,7 @@
         "trim_blocks": true
       },
       "_template": "https://github.com/scverse/cookiecutter-scverse",
-      "_commit": "d383d94fadff9e4e6fdb59d77c68cb900d7cedec"
+      "_commit": "6ff5b92b5d44ea6d8a88e47538475718d467db95"
     }
   },
   "directory": null

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Report something that is broken or incorrect
-labels: bug
+type: Bug
 body:
   - type: markdown
     attributes:
@@ -9,8 +9,7 @@ body:
         detailing how to provide the necessary information for us to reproduce your bug. In brief:
           * Please provide exact steps how to reproduce the bug in a clean Python environment.
           * In case it's not clear what's causing this bug, please provide the data or the data generation procedure.
-          * Sometimes it is not possible to share the data, but usually it is possible to replicate problems on publicly
-            available datasets or to share a subset of your data.
+          * Sometimes it is not possible to share the data, but usually it is possible to replicate problems on publicly available datasets or to share a subset of your data.
 
   - type: textarea
     id: report

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Propose a new feature for scembed
-labels: enhancement
+type: Enhancement
 body:
   - type: textarea
     id: description

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,23 +10,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-defaults:
-  run:
-    # to fail on error in multiline statements (-e), in pipes (-o pipefail), and on unset variables (-u).
-    shell: bash -euo pipefail {0}
-
 jobs:
   package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           filter: blob:none
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          cache-dependency-glob: pyproject.toml
+        uses: astral-sh/setup-uv@v7
       - name: Build package
         run: uv build
       - name: Check package

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,11 +4,6 @@ on:
   release:
     types: [published]
 
-defaults:
-  run:
-    # to fail on error in multiline statements (-e), in pipes (-o pipefail), and on unset variables (-u).
-    shell: bash -euo pipefail {0}
-
 # Use "trusted publishing", see https://docs.pypi.org/trusted-publishers/
 jobs:
   release:
@@ -20,14 +15,12 @@ jobs:
     permissions:
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           filter: blob:none
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          cache-dependency-glob: pyproject.toml
+        uses: astral-sh/setup-uv@v7
       - name: Build package
         run: uv build
       - name: Publish package distributions to PyPI

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,11 +12,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-defaults:
-  run:
-    # to fail on error in multiline statements (-e), in pipes (-o pipefail), and on unset variables (-u).
-    shell: bash -euo pipefail {0}
-
 jobs:
   # Get the test environment from hatch as defined in pyproject.toml.
   # This ensures that the pyproject.toml is the single point of truth for test definitions and the same tests are
@@ -28,12 +23,12 @@ jobs:
     outputs:
       envs: ${{ steps.get-envs.outputs.envs }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           filter: blob:none
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
       - name: Get test environments
         id: get-envs
         run: |
@@ -60,17 +55,17 @@ jobs:
 
     name: ${{ matrix.env.label }}
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ contains(matrix.env.name, 'pre') }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           filter: blob:none
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.env.python }}
-          cache-dependency-glob: pyproject.toml
       - name: create hatch environment
         run: uvx hatch env create ${{ matrix.env.name }}
       - name: run tests using hatch

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,8 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.12"
+    python: "3.13"
+    nodejs: latest
   jobs:
     create_environment:
       - asdf plugin add uv

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,10 +5,13 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 # -- Path setup --------------------------------------------------------------
+import shutil
 import sys
 from datetime import datetime
 from importlib.metadata import metadata
 from pathlib import Path
+
+from sphinxcontrib import katex
 
 HERE = Path(__file__).parent
 sys.path.insert(0, str(HERE / "extensions"))
@@ -19,7 +22,7 @@ sys.path.insert(0, str(HERE / "extensions"))
 # NOTE: If you installed your project in editable mode, this might be stale.
 #       If this is the case, reinstall it to refresh the metadata
 info = metadata("scembed")
-project_name = info["Name"]
+project = info["Name"]
 author = info["Author"]
 copyright = f"{datetime.now():%Y}, {author}."
 version = info["Version"]
@@ -37,7 +40,7 @@ needs_sphinx = "4.0"
 html_context = {
     "display_github": True,  # Integrate GitHub
     "github_user": "quadbio",
-    "github_repo": project_name,
+    "github_repo": project,
     "github_version": "main",
     "conf_py_path": "/docs/",
 }
@@ -56,7 +59,7 @@ extensions = [
     "sphinxcontrib.bibtex",
     "sphinx_autodoc_typehints",
     "sphinx_tabs.tabs",
-    "sphinx.ext.mathjax",
+    "sphinxcontrib.katex",
     "IPython.sphinxext.ipython_console_highlighting",
     "sphinxext.opengraph",
     *[p.stem for p in (HERE / "extensions").glob("*.py")],
@@ -86,6 +89,9 @@ nb_execution_mode = "off"
 nb_merge_streams = True
 typehints_defaults = "braces"
 
+# Use prerendered KaTeX when a Node.js binary is available (RTD), fall back otherwise.
+katex_prerender = shutil.which(katex.NODEJS_BINARY) is not None
+
 source_suffix = {
     ".rst": "restructuredtext",
     ".ipynb": "myst-nb",
@@ -93,7 +99,8 @@ source_suffix = {
 }
 
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3", None),
+    # TODO: revert to https://docs.python.org/3 once RTD supports Python 3.14
+    "python": ("https://docs.python.org/3.13", None),
     "anndata": ("https://anndata.readthedocs.io/en/stable/", None),
     "scanpy": ("https://scanpy.readthedocs.io/en/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
@@ -121,7 +128,7 @@ html_theme = "sphinx_book_theme"
 html_static_path = ["_static"]
 html_css_files = ["css/custom.css"]
 
-html_title = project_name
+html_title = project
 
 html_theme_options = {
     "repository_url": repository_url,

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -62,9 +62,9 @@ This will list “Standalone” environments and a table of “Matrix” environ
 +------------+---------+--------------------------+----------+---------------------------------+-------------+
 | Name       | Type    | Envs                     | Features | Dependencies                    | Scripts     |
 +------------+---------+--------------------------+----------+---------------------------------+-------------+
-| hatch-test | virtual | hatch-test.py3.10-stable | dev      | coverage-enable-subprocess==1.0 | cov-combine |
-|            |         | hatch-test.py3.13-stable | test     | coverage[toml]~=7.4             | cov-report  |
-|            |         | hatch-test.py3.13-pre    |          | pytest-mock~=3.12               | run         |
+| hatch-test | virtual | hatch-test.py3.11-stable | dev      | coverage-enable-subprocess==1.0 | cov-combine |
+|            |         | hatch-test.py3.14-stable | test     | coverage[toml]~=7.4             | cov-report  |
+|            |         | hatch-test.py3.14-pre    |          | pytest-mock~=3.12               | run         |
 |            |         |                          |          | pytest-randomly~=3.15           | run-cov     |
 |            |         |                          |          | pytest-rerunfailures~=14.0      |             |
 |            |         |                          |          | pytest-xdist[psutil]~=3.5       |             |
@@ -73,18 +73,18 @@ This will list “Standalone” environments and a table of “Matrix” environ
 ```
 
 From the `Envs` column, select the environment name you want to use for development.
-In this example, it would be `hatch-test.py3.13-stable`.
+In this example, it would be `hatch-test.py3.14-stable`.
 
 Next, create the environment with
 
 ```bash
-hatch env create hatch-test.py3.13-stable
+hatch env create hatch-test.py3.14-stable
 ```
 
 Then, obtain the path to the environment using
 
 ```bash
-hatch env find hatch-test.py3.13-stable
+hatch env find hatch-test.py3.14-stable
 ```
 
 In case you are using VScode, now open the command palette (Ctrl+Shift+P) and search for `Python: Select Interpreter`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,11 +40,35 @@ optional-dependencies.cpu = [
   "pyliger>=0.2.4",
   "scanorama>=1.7.4",
 ]
-optional-dependencies.dev = [
+optional-dependencies.fast-metrics = [
+  "faiss-cpu",         # Fast nearest neighbors (GPU via rapids-singlecell)
+  "rapids-singlecell", # GPU-accelerated single-cell analysis
+]
+
+optional-dependencies.gpu = [
+  "harmony-pytorch", # GPU-accelerated Harmony
+  "scarches>=0.6.1", # for scPoli
+  "scvi-tools>=1.3",
+  "torch>=2.8",
+]
+# https://docs.pypi.org/project_metadata/#project-urls
+urls.Documentation = "https://scembed.readthedocs.io/"
+urls.Homepage = "https://github.com/quadbio/scembed"
+urls.Source = "https://github.com/quadbio/scembed"
+
+[dependency-groups]
+dev = [
   "pre-commit",
   "twine>=4.0.2",
 ]
-optional-dependencies.doc = [
+test = [
+  "coverage>=7.10",
+  "h5py",           # for testing h5 format
+  "pyarrow",        # for testing parquet format (already in main deps but explicit for tests)
+  "pytest",
+  "pytest-cov",     # For VS Code's coverage functionality
+]
+doc = [
   "docutils>=0.8,!=0.18.*,!=0.19.*",
   "ipykernel",
   "ipython",
@@ -58,53 +82,30 @@ optional-dependencies.doc = [
   "sphinx-copybutton",
   "sphinx-tabs",
   "sphinxcontrib-bibtex>=1",
+  "sphinxcontrib-katex",
   "sphinxext-opengraph",
 ]
-optional-dependencies.fast-metrics = [
-  "faiss-cpu",         # Fast nearest neighbors (GPU via rapids-singlecell)
-  "rapids-singlecell", # GPU-accelerated single-cell analysis
-]
-
-optional-dependencies.gpu = [
-  "harmony-pytorch", # GPU-accelerated Harmony
-  "scarches>=0.6.1", # for scPoli
-  "scvi-tools>=1.3",
-  "torch>=2.8",
-]
-
-optional-dependencies.test = [
-  "coverage>=7.10",
-  "h5py",           # for testing h5 format
-  "pyarrow",        # for testing parquet format (already in main deps but explicit for tests)
-  "pytest",
-  "pytest-cov",     # For VS Code's coverage functionality
-  "scembed[cpu]",
-  "scembed[gpu]",
-]
-# https://docs.pypi.org/project_metadata/#project-urls
-urls.Documentation = "https://scembed.readthedocs.io/"
-urls.Homepage = "https://github.com/quadbio/scembed"
-urls.Source = "https://github.com/quadbio/scembed"
 
 [tool.hatch.version]
 source = "vcs"
 
 [tool.hatch.envs.default]
 installer = "uv"
-features = [ "dev" ]
+dependency-groups = [ "dev" ]
 
 [tool.hatch.envs.docs]
-features = [ "doc" ]
+dependency-groups = [ "doc" ]
 scripts.build = "sphinx-build -M html docs docs/_build {args}"
 scripts.open = "python -m webbrowser -t docs/_build/html/index.html"
 scripts.clean = "git clean -fdX -- {args:docs}"
 
 # Test the lowest and highest supported Python versions with stable deps
 [[tool.hatch.envs.hatch-test.matrix]]
-python = [ "3.11", "3.13" ]
+python = [ "3.11", "3.14" ]
 
 [tool.hatch.envs.hatch-test]
-features = [ "dev", "test" ]
+features = [ "cpu", "gpu" ]
+dependency-groups = [ "dev", "test" ]
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ optional-dependencies.fast-metrics = [
 
 optional-dependencies.gpu = [
   "harmony-pytorch", # GPU-accelerated Harmony
+  "lightning",       # transitive via scvi-tools, declared here so the [tool.uv.sources] redirect applies
   "scarches>=0.6.1", # for scPoli
   "scvi-tools>=1.3",
   "torch>=2.8",
@@ -89,6 +90,12 @@ doc = [
 [tool.hatch.version]
 source = "vcs"
 
+# Workaround: PyPI has quarantined the `lightning` distribution
+# (https://pypi.org/simple/lightning/ -> project-status: quarantined, zero
+# files). `scvi-tools` depends on `lightning>=2.0`, so any environment with
+# the `[gpu]` extra fails to resolve. Pull `lightning` from the upstream
+# GitHub monorepo instead until PyPI restores the package, then drop this
+# block.
 [tool.hatch.envs.default]
 installer = "uv"
 dependency-groups = [ "dev" ]
@@ -106,6 +113,9 @@ python = [ "3.11", "3.14" ]
 [tool.hatch.envs.hatch-test]
 features = [ "cpu", "gpu" ]
 dependency-groups = [ "dev", "test" ]
+
+[tool.uv.sources]
+lightning = { git = "https://github.com/Lightning-AI/pytorch-lightning", tag = "2.6.2" }
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
## Summary

Apply the still-relevant diffs from cookiecutter-scverse `v0.7.0` on top of
current `main`. Replaces the stale auto-PR #18 (which is now far enough
behind that a clean cherry-pick is simpler than a rebase).

## Behavior or invariants changed

- `[project.optional-dependencies].test` is **removed**. Test tooling now
  lives in `[dependency-groups].test` (PEP 735). The hatch-test env keeps
  CPU + GPU coverage via `features = ["cpu", "gpu"]` plus
  `dependency-groups = ["dev", "test"]`. Anyone previously running
  `pip install scembed[test]` should switch to `uv sync --group test` (or
  install `cpu` / `gpu` extras directly).
- Hatch test matrix: Python `["3.11", "3.13"]` → `["3.11", "3.14"]`.
- Pre-release matrix runs no longer block CI (`continue-on-error: true`
  when the env name contains `pre`).
- KaTeX replaces MathJax for docs math rendering (RTD now has Node.js).

## Out of scope (intentionally not adopted)

- Codecov OIDC: kept on the existing token. Will be a separate change if/when
  we want it.
- Pre-commit hook autoupdates (biome, pyproject-fmt, ruff): handled in a
  follow-up PR that branches off this one.
- Agent-neutral repo guides / `.github/copilot-instructions.md` rewrite:
  separate docs PR.

## Tests run

- `uvx hatch env show -i` lists the new `hatch-test.py3.11` and
  `hatch-test.py3.14` envs with `features = [cpu, gpu]` and
  `dependency-groups = [dev, test]`.
- `uvx hatch run docs:build` succeeds locally (KaTeX + sphinxcontrib-katex
  install correctly into the docs env).
- Pre-commit hooks pass (current versions; the autoupdate PR will reformat
  the new `pyproject.toml` once merged).

## Reviewer focus

- `pyproject.toml`: the `optional-dependencies.test` removal and the
  hatch-test env layout (CPU+GPU features + dev/test groups).
- `docs/conf.py`: KaTeX swap and the `katex_prerender` guard.
- Workflows: confirm the dropped `defaults.run.shell` block doesn't break
  any multi-line `run:` step.

## Closes

Supersedes #18.
