### PR TITLE
chore: pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,16 +7,16 @@ default_stages:
 minimum_pre_commit_version: 2.16.0
 repos:
   - repo: https://github.com/biomejs/pre-commit
-    rev: v2.3.10
+    rev: v2.4.13
     hooks:
       - id: biome-format
         exclude: ^\.cruft\.json$ # inconsistent indentation with cruft - file never to be modified manually.
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.11.1
+    rev: v2.21.1
     hooks:
       - id: pyproject-fmt
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.10
+    rev: v0.15.12
     hooks:
       - id: ruff-check
         types_or: [python, pyi, jupyter]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,15 +84,6 @@ doc = [
   "sphinxext-opengraph",
 ]
 
-# Workaround: PyPI has quarantined the `lightning` distribution
-# (https://pypi.org/simple/lightning/ -> project-status: quarantined, zero
-# files). `scvi-tools` depends on `lightning>=2.0`, so any environment with
-# the `[gpu]` extra fails to resolve. Pull `lightning` from the upstream
-# GitHub monorepo instead until PyPI restores the package, then drop this
-# block (and the matching entry in `optional-dependencies.gpu`).
-[tool.uv.sources]
-lightning = { git = "https://github.com/Lightning-AI/pytorch-lightning", tag = "2.6.2" }
-
 [tool.hatch]
 envs.default.installer = "uv"
 envs.default.dependency-groups = [ "dev" ]
@@ -107,6 +98,15 @@ envs.hatch-test.matrix = [
   { python = [ "3.11", "3.14" ] },
 ]
 version.source = "vcs"
+
+[tool.uv]
+# Workaround: PyPI has quarantined the `lightning` distribution
+# (https://pypi.org/simple/lightning/ -> project-status: quarantined, zero
+# files). `scvi-tools` depends on `lightning>=2.0`, so any environment with
+# the `[gpu]` extra fails to resolve. Pull `lightning` from the upstream
+# GitHub monorepo instead until PyPI restores the package, then drop this
+# block (and the matching entry in `optional-dependencies.gpu`).
+sources.lightning = { git = "https://github.com/Lightning-AI/pytorch-lightning", tag = "2.6.2" }
 
 [tool.ruff]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
 ]
 dynamic = [ "version" ]
-
 dependencies = [
   "numpy>=2.1",
   "pyarrow>=20",         # Required for parquet support in pandas
@@ -32,7 +31,6 @@ dependencies = [
   "session-info2",
   "wandb",
 ]
-
 optional-dependencies.all = [
   "scembed[cpu,fast-metrics,gpu]",
 ]
@@ -44,7 +42,6 @@ optional-dependencies.fast-metrics = [
   "faiss-cpu",         # Fast nearest neighbors (GPU via rapids-singlecell)
   "rapids-singlecell", # GPU-accelerated single-cell analysis
 ]
-
 optional-dependencies.gpu = [
   "harmony-pytorch", # GPU-accelerated Harmony
   "lightning",       # transitive via scvi-tools, declared here so the [tool.uv.sources] redirect applies
@@ -87,43 +84,35 @@ doc = [
   "sphinxext-opengraph",
 ]
 
-[tool.hatch.version]
-source = "vcs"
-
 # Workaround: PyPI has quarantined the `lightning` distribution
 # (https://pypi.org/simple/lightning/ -> project-status: quarantined, zero
 # files). `scvi-tools` depends on `lightning>=2.0`, so any environment with
 # the `[gpu]` extra fails to resolve. Pull `lightning` from the upstream
 # GitHub monorepo instead until PyPI restores the package, then drop this
-# block.
-[tool.hatch.envs.default]
-installer = "uv"
-dependency-groups = [ "dev" ]
-
-[tool.hatch.envs.docs]
-dependency-groups = [ "doc" ]
-scripts.build = "sphinx-build -M html docs docs/_build {args}"
-scripts.open = "python -m webbrowser -t docs/_build/html/index.html"
-scripts.clean = "git clean -fdX -- {args:docs}"
-
-# Test the lowest and highest supported Python versions with stable deps
-[[tool.hatch.envs.hatch-test.matrix]]
-python = [ "3.11", "3.14" ]
-
-[tool.hatch.envs.hatch-test]
-features = [ "cpu", "gpu" ]
-dependency-groups = [ "dev", "test" ]
-
+# block (and the matching entry in `optional-dependencies.gpu`).
 [tool.uv.sources]
 lightning = { git = "https://github.com/Lightning-AI/pytorch-lightning", tag = "2.6.2" }
+
+[tool.hatch]
+envs.default.installer = "uv"
+envs.default.dependency-groups = [ "dev" ]
+envs.docs.dependency-groups = [ "doc" ]
+envs.docs.scripts.build = "sphinx-build -M html docs docs/_build {args}"
+envs.docs.scripts.open = "python -m webbrowser -t docs/_build/html/index.html"
+envs.docs.scripts.clean = "git clean -fdX -- {args:docs}"
+envs.hatch-test.features = [ "cpu", "gpu" ]
+envs.hatch-test.dependency-groups = [ "dev", "test" ]
+envs.hatch-test.matrix = [
+  # Test the lowest and highest supported Python versions with stable deps
+  { python = [ "3.11", "3.14" ] },
+]
+version.source = "vcs"
 
 [tool.ruff]
 line-length = 120
 src = [ "src" ]
 extend-include = [ "*.ipynb" ]
-
 format.docstring-code-format = true
-
 lint.select = [
   "B",      # flake8-bugbear
   "BLE",    # flake8-blind-except
@@ -157,19 +146,19 @@ lint.per-file-ignores."docs/*" = [ "I" ]
 lint.per-file-ignores."tests/*" = [ "D" ]
 lint.pydocstyle.convention = "numpy"
 
-[tool.pytest.ini_options]
-testpaths = [ "tests" ]
-xfail_strict = true
-addopts = [
+[tool.pytest]
+ini_options.testpaths = [ "tests" ]
+ini_options.xfail_strict = true
+ini_options.addopts = [
   "--import-mode=importlib", # allow using test files with same name
 ]
 
-[tool.coverage.run]
-source = [ "scembed" ]
-patch = [ "subprocess" ]
-omit = [
+[tool.coverage]
+run.omit = [
   "**/test_*.py",
 ]
+run.patch = [ "subprocess" ]
+run.source = [ "scembed" ]
 
 [tool.cruft]
 skip = [


### PR DESCRIPTION
## Summary

Pre-commit hook autoupdate. Replaces stale auto-PR #19. Stacked on top of
#20 because pyproject-fmt v2.21 reformats the new `[dependency-groups]`
layout introduced there.

## Changes

- `biomejs/pre-commit` v2.3.10 → v2.4.13
- `tox-dev/pyproject-fmt` v2.11.1 → v2.21.1
- `astral-sh/ruff-pre-commit` v0.14.10 → v0.15.12
- `pyproject.toml` reformat: `[tool.pytest.ini_options]` → `[tool.pytest]`
  with `ini_options.*` flat keys; same for `[tool.coverage]`. No behavior
  change — pyproject-fmt v2.21's preferred layout.

## Tests run

- `uvx pre-commit run --all-files` — all hooks pass.
- Second run is idempotent.

## Reviewer focus

The `pyproject.toml` reformat looks larger than it is — it's purely
flatten-into-dotted-keys.

## Closes

Supersedes #19. Merge after #20.
