### PR TITLE
docs: add agent-neutral repo guides (AGENTS.md, REVIEW_GUIDE.md)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+## Summary
+
+Describe the change in 2-5 sentences.
+
+## Behavior Or Invariants Changed
+
+Call out any behavior changes and any repo invariants touched.
+If none, say "None".
+
+## Tests Run
+
+List the commands you ran and anything you intentionally did not run.
+
+## Reviewer Focus
+
+Point reviewers to the highest-risk files, code paths, or assumptions.
+
+## Context
+
+Add any domain context, dataset assumptions, or implementation background that is not obvious from the diff.
+
+## Open Questions Or Follow-Ups
+
+List anything intentionally deferred, uncertain, or worth extra scrutiny.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,63 +1,7 @@
 # Copilot Instructions for scembed
 
-## Project Overview
+Canonical repo guidance lives in:
+- `AGENTS.md` — invariants, source-of-truth map, and development commands
+- `REVIEW_GUIDE.md` — PR review workflow, risk areas, and changed-path test lookup
 
-**scembed** is a Python package for comparing single-cell data integration
-methods using [scIB metrics](https://scib-metrics.readthedocs.io/). It wraps
-common integration tools, facilitates benchmarking with scIB, and aggregates
-results from W&B sweeps run via [slurm_sweep](https://github.com/quadbio/slurm_sweep).
-
-### Domain Context
-- **Integration methods**: Remove batch effects while preserving biological
-  variation. Examples: Harmony (CPU), scVI/scANVI/scPoli (GPU, from scvi-tools).
-- **scIB metrics**: Benchmark integration quality via batch correction (iLISI,
-  KBET) and bio conservation (ARI, NMI, silhouette).
-- **W&B (Weights & Biases)**: Experiment tracking. We log configs, metrics,
-  embeddings, and models as artifacts.
-
-### Key Dependencies
-- **Core**: scanpy, anndata, scib-metrics, wandb
-- **Integration methods**: Optional extras `[cpu]`, `[gpu]`, `[fast-metrics]`
-- **scvi-tools**: PyTorch-based methods (scVI, scANVI, scPoli)
-
-## Architecture
-
-### Core Components
-1. **`src/scembed/methods/`**: Wrappers for integration methods
-   - Base class: `BaseIntegrationMethod` (abstract)
-   - CPU methods: Harmony, LIGER, Scanorama, precomputed PCA
-   - GPU methods: scVI, scANVI, scPoli, ResolVI
-2. **`src/scembed/evaluation.py`**: `IntegrationEvaluator` for scIB benchmarking
-3. **`src/scembed/aggregation.py`**: `scIBAggregator` for W&B sweep result aggregation
-4. **`src/scembed/utils.py`**: Utilities (subsampling, artifact download, embedding I/O)
-
-## Project-Specific Patterns
-
-### Working with Integration Methods
-```python
-method = HarmonyMethod(
-    adata=adata,
-    batch_key="batch",
-    cell_type_key="celltype",
-    output_dir=Path("outputs"),
-)
-method.integrate()  # creates .obsm['X_harmony']
-method.save_embedding()
-```
-
-### W&B Integration
-- Methods can log to W&B via `wandb.init()` (typically in training scripts)
-- Artifacts logged: trained models, embeddings
-- `scIBAggregator` fetches and processes sweep results from W&B API
-- Handle W&B SDK version differences gracefully (see helper methods in `aggregation.py`)
-
-## Common Gotchas
-
-1. **Optional dependencies**: CPU/GPU methods require respective extras. Check with `check_deps()` from `scembed.check`.
-2. **W&B API changes**: SDK behavior varies across versions. Use helper methods for parsing run data (see `aggregation.py`).
-
-## Related Resources
-
-- **scIB metrics docs**: https://scib-metrics.readthedocs.io/
-- **scvi-tools docs**: https://docs.scvi-tools.org/
-- **slurm_sweep**: https://github.com/quadbio/slurm_sweep
+If this file conflicts with those guides, the guides win.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,88 @@
+# AGENTS.md — scembed
+
+`scembed` is a Python package for benchmarking single-cell data integration
+methods with [scIB metrics][]. It wraps common integration tools (Harmony,
+LIGER, Scanorama, scVI, scANVI, scPoli, ResolVI, scVIVA), drives benchmarks
+through [scIB metrics][], and aggregates W&B sweep results produced via
+[slurm_sweep][].
+
+[scIB metrics]: https://scib-metrics.readthedocs.io/
+[slurm_sweep]: https://github.com/quadbio/slurm_sweep
+
+## Trust Order
+
+When sources disagree:
+1. PR description and changed code
+2. This file (`AGENTS.md`)
+3. `REVIEW_GUIDE.md`
+4. Tests under `tests/`
+5. Public docs in `docs/`
+
+This file owns invariants and the where-to-find table. Review-specific
+workflow lives in `REVIEW_GUIDE.md`.
+
+## Where To Find What
+
+| Topic | Source of truth |
+|-------|-----------------|
+| Method registry / dispatch | `src/scembed/factory.py` (`get_method_instance`) |
+| Method base class & embedding-key convention | `src/scembed/methods/base.py` (`BaseIntegrationMethod`) |
+| CPU-only methods (HVG, LIGER, Scanorama, precomputed) | `src/scembed/methods/cpu_methods.py` |
+| GPU/torch methods (Harmony, scVI, scANVI, scPoli, ResolVI, scVIVA) | `src/scembed/methods/gpu_methods.py` |
+| scIB benchmarking | `src/scembed/evaluation.py` (`IntegrationEvaluator`) |
+| W&B sweep aggregation | `src/scembed/aggregation.py` (`scIBAggregator`) |
+| Optional-dependency gating | `src/scembed/check.py` (`check_deps`, `CHECKERS`) |
+| Public API surface | `src/scembed/__init__.py` |
+| Contributor guide | `docs/contributing.md` |
+| Usage examples | `docs/notebooks/basic_usage.ipynb` |
+| PR review workflow & risk areas | `REVIEW_GUIDE.md` |
+| Test fixtures | `tests/conftest.py` |
+| Sweep driver | <https://github.com/quadbio/slurm_sweep> |
+
+## Review Guidelines
+
+For GitHub PR reviews, use `REVIEW_GUIDE.md` as the canonical review workflow
+and source of review-specific risk areas, testing checks, and
+documentation-impact checks. This file only owns the project invariants and
+the source-of-truth map above.
+
+## Critical Invariants
+
+- Every integration method subclasses `BaseIntegrationMethod` and writes its
+  result into `adata.obsm["X_<name>"]`, where
+  `name = ClassName.replace("Method", "").lower()`. Examples:
+  `HarmonyMethod` → `X_harmony`, `scVIMethod` → `X_scvi`.
+- New methods register their dependency keys in `CHECKERS`
+  (`src/scembed/check.py`) and call `check_deps(...)` **before** importing
+  the optional package. This is what gives users a clear error when an extra
+  is missing.
+- Optional install extras and the methods they enable:
+  - **`[cpu]`** — `pyliger`, `scanorama`. Used by `LIGERMethod`,
+    `ScanoramaMethod`. (`HVGMethod` and `PrecomputedEmbeddingMethod` need
+    no extra.)
+  - **`[gpu]`** — `harmony-pytorch`, `scvi-tools`, `scarches`, `torch`. Used
+    by `HarmonyMethod`, `scVIMethod`, `scANVIMethod`, `scVIVAMethod`,
+    `ResolVIMethod`, `scPoliMethod`. **`scPoliMethod` depends on `scarches`,
+    not `scvi-tools`.**
+  - **`[fast-metrics]`** — `faiss-cpu`, `rapids-singlecell`.
+- W&B SDK version differences are isolated in helper methods inside
+  `aggregation.py`. Don't sprinkle SDK-version checks elsewhere.
+- Public API is whatever `src/scembed/__init__.py` exports
+  (`IntegrationEvaluator`, `scIBAggregator`, `get_method_instance`, `logger`,
+  `methods`). Keep that surface minimal — submodule symbols stay private
+  unless explicitly re-exported.
+- Tests mirror the module layout: `src/scembed/X/` → `tests/X/`. Method
+  tests live in `tests/methods/`; everything else is flat under `tests/`.
+
+## Development Commands
+
+Python 3.11 and 3.14 are the matrix endpoints (see
+`[tool.hatch.envs.hatch-test.matrix]`).
+
+```bash
+uv sync                             # install with default groups
+uvx hatch test                      # run tests on highest matrix Python
+uvx hatch test --all                # full matrix (3.11, 3.14)
+uvx hatch run docs:build            # build Sphinx docs
+uvx pre-commit run --all-files      # lint + format (biome, pyproject-fmt, ruff)
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+# scembed Agent Entry Point
+
+@AGENTS.md
+
+Use `REVIEW_GUIDE.md` for the PR review workflow, risk areas, and
+changed-path test lookup.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ in particular, the [API documentation][].
 
 ## 📦 Installation
 
-You need to have Python 3.10 or newer installed on your system.
+You need to have Python 3.11 or newer installed on your system.
 If you don't have Python installed, we recommend installing [uv][].
 
 There are several alternative options to install scembed:
@@ -55,9 +55,9 @@ pip install git+https://github.com/quadbio/scembed.git@main
 The package uses optional dependency groups to minimize installation overhead:
 
 - **Base**: Core functionality (scanpy, scib-metrics, wandb)
-- **`[cpu]`**: CPU-based methods (e.g. Harmony, LIGER, Scanorama)
-- **`[gpu]`**: GPU-based methods (e.g. scVI, scANVI, scPoli)
-- **`[fast_metrics]`**: Accelerated evaluation with `faiss` and `RAPIDS` ⚡
+- **`[cpu]`**: CPU-only methods (e.g. LIGER, Scanorama)
+- **`[gpu]`**: GPU/torch-based methods (e.g. Harmony, scVI, scANVI, scPoli)
+- **`[fast-metrics]`**: Accelerated evaluation with `faiss` and `RAPIDS` ⚡
 - **`[all]`**: All optional dependencies
 
 **⚠️ Notes**:

--- a/REVIEW_GUIDE.md
+++ b/REVIEW_GUIDE.md
@@ -1,0 +1,137 @@
+# scembed Review Guide
+
+This file is the canonical, agent-neutral source of truth for automated PR review in this repo.
+It is written for **agents performing PR reviews on GitHub** — use the imperative voice and be concrete.
+
+**Scope: review only.** Your job is to produce review comments and suggestions on the PR. Do **not** push commits, modify files, or apply fixes yourself. Any changes are the author's call. Flag issues, ask questions, and suggest concrete diffs in comments when helpful — but leave the decision and the edits to the user.
+
+Use `AGENTS.md` for invariants, the source-of-truth map, and development commands. Use this guide for review workflow, risk areas, testing checks, documentation-impact checks, and changed-path test lookup.
+
+## Review-First Workflow
+
+1. Read the PR body first when it is present.
+2. Check CI status (`gh pr checks <num>`, `gh run view <run-id> --log-failed`) and investigate any test or lint failures before commenting.
+3. Identify changed modules and map them to matching tests (see [Changed-Path Test Lookup](#changed-path-test-lookup)).
+4. Check whether the change touches a repo invariant from `AGENTS.md`.
+5. Prioritize behavioral regressions, optional-dep gating, and W&B/SDK compatibility over style feedback.
+6. Verify that docs (human- and agent-facing) did not become stale — see [Documentation Impact](#documentation-impact).
+
+## High-Risk Areas
+
+- `BaseIntegrationMethod` contract:
+  changes to constructor kwargs, `validate_adata`, the abstract `integrate()`
+  signature, or the auto-derived `embedding_key` propagate to every method
+  subclass and to anything that reads `adata.obsm["X_<name>"]`.
+- Optional-dependency gating in `methods/cpu_methods.py` and
+  `methods/gpu_methods.py`: every optional import must be preceded by a
+  matching `check_deps(...)` call, and new keys must be registered in
+  `CHECKERS` (`src/scembed/check.py`).
+- W&B SDK drift in `aggregation.py`: the helper methods that parse run
+  configs and history are the SDK-version isolation layer; changes there can
+  silently break sweep result aggregation against older or newer `wandb`.
+- scIB benchmark configuration in `evaluation.py`: silent changes to the
+  metric set, neighbor graph, or embedding lookup can shift benchmark
+  numbers without any test failure.
+- Public API surface in `src/scembed/__init__.py`: every new re-export is a
+  long-term commitment. Prefer keeping internals private and importing from
+  the submodule.
+- Method-name → embedding-key mapping: anything that derives `name` from the
+  class name affects every saved embedding. Renaming a method class
+  silently changes which `obsm` key the result lands in.
+
+## Changed-Path Test Lookup
+
+Test files mostly mirror module layout under `src/scembed/`:
+
+| Changed path | Tests to check |
+|---|---|
+| `src/scembed/methods/base.py` | `tests/methods/test_base.py` |
+| `src/scembed/methods/cpu_methods.py` | `tests/methods/test_cpu_methods.py` |
+| `src/scembed/methods/gpu_methods.py` | `tests/methods/test_gpu_methods.py` |
+| `src/scembed/evaluation.py` | `tests/test_evaluation.py` |
+| `src/scembed/aggregation.py` | `tests/test_aggregation.py` |
+| `src/scembed/factory.py` | `tests/test_basic.py` |
+| `src/scembed/utils.py` | `tests/test_basic.py`, `tests/test_retrival.py` |
+| `src/scembed/check.py` | `tests/test_basic.py` |
+
+Cross-cutting fixture changes: inspect `tests/conftest.py` and any test
+that uses the modified fixture.
+
+## Testing
+
+Apply these checks whenever the PR touches code or tests.
+
+**New code.** Confirm that new behavior is covered by tests.
+- Reuse fixtures from `tests/conftest.py` rather than creating parallel ones.
+- Prefer `pytest.mark.parametrize` over many near-identical tests.
+- Favor few meaningful tests over many redundant ones; flag low-value tests
+  that only duplicate existing coverage.
+
+**Failing tests.** If CI is red, do not wave it through.
+- Inspect which tests fail and why (`gh pr checks`, `gh run view --log-failed`).
+- Distinguish critical regressions (method outputs, optional-dep gating,
+  W&B parsing) from trivial or flaky failures.
+- Surface critical failures back to the author and ask them to fix before
+  merge.
+
+**Modified tests.** Scrutinize *how* existing tests were changed.
+- PRs that only relax thresholds, remove assertions, delete cases, or loosen
+  `parametrize` matrices are a red flag — tests-working-around-tests defeats
+  the purpose.
+- Require an explicit justification in the PR body for any weakened
+  assertion; do not accept silently.
+
+## Documentation Impact
+
+A single behavioral or API change often touches docs in multiple places.
+Check both audiences and ask the author to update what is stale. Point to
+the **owning file** for each topic rather than duplicating content in your
+review.
+
+**Human-facing docs (`docs/`, Sphinx/RTD).**
+- API signature or public symbol changes → `docs/api.md` and autosummary
+  entries; any prose referencing the symbol.
+- Contributor workflow, environment, or CI changes → `docs/contributing.md`.
+- New methods, extras, or behavioral changes → `README.md` and
+  `docs/notebooks/basic_usage.ipynb`.
+
+**Agent-facing docs (repo root and `.github/`).**
+- Invariants or development commands changed → `AGENTS.md` (Critical
+  Invariants, Development Commands).
+- Review workflow, risk areas, or testing conventions changed →
+  `REVIEW_GUIDE.md` (this file).
+- Repo structure, new top-level docs, or moved pointers → `AGENTS.md`
+  "Where To Find What" table, `CLAUDE.md`, `.github/copilot-instructions.md`.
+
+If behavior changes but the relevant docs do not, call it out explicitly
+in the review and request the update.
+
+## Review Checklist
+
+- Does the change preserve the invariants in `AGENTS.md`?
+- Does CI pass, and were any failures investigated? (See [Testing](#testing).)
+- Is test coverage adequate and non-redundant, and are modified tests not
+  simply weakened? (See [Testing](#testing).)
+- For new methods: does the class subclass `BaseIntegrationMethod`, gate
+  imports through `check_deps`, register a `CHECKERS` entry, and produce
+  the expected `adata.obsm["X_<name>"]` key?
+- Does it change scIB benchmark configuration, embedding lookup, or W&B
+  parsing in a way that needs explicit release-note-style mention in the
+  PR?
+- Are all affected human- and agent-facing docs updated? (See
+  [Documentation Impact](#documentation-impact).)
+- Is the PR scope tight — no unrelated changes bundled in — and is the
+  public API surface kept minimal?
+
+## PR Metadata
+
+This repo uses a structured PR template.
+
+Reviewers and agents should treat these sections as the preferred summary
+surface:
+- summary
+- behavior or invariants changed
+- tests run
+- reviewer focus
+- context
+- open questions or follow-ups


### PR DESCRIPTION
## Summary

Adopt the avanti-style agent-neutral docs layout so AI agents (and humans)
have a single canonical, factually-correct source of truth for the repo.

## Behavior or invariants changed

None — docs only. **However**, this PR fixes several factual errors that
were present in the previous `.github/copilot-instructions.md` and in
`README.md`. The errors are not a functional change to the package.

### Errors fixed (verified against `src/scembed/`)

| Old claim | Reality |
|---|---|
| "CPU methods: Harmony, LIGER, Scanorama, precomputed PCA" | `HarmonyMethod` lives in `methods/gpu_methods.py` and depends on `harmony-pytorch` (the `[gpu]` extra). The `[cpu]` extra ships `pyliger` + `scanorama` only. |
| "GPU methods: scVI, scANVI, scPoli (from scvi-tools)" | `scPoliMethod` depends on `scarches`, not `scvi-tools` (`check_deps("scarches")` in `gpu_methods.py`). |
| Method list missing `HVGMethod`, `ResolVIMethod`, `scVIVAMethod` | All three exist and are exported from `scembed.methods`. |
| README: "Python 3.10 or newer" | `pyproject.toml` already requires `>=3.11`. |
| README: `[fast_metrics]` | Actual extra is `[fast-metrics]`. |

## Files

- `AGENTS.md` (new): invariants, where-to-find-what map, dev commands.
- `REVIEW_GUIDE.md` (new): PR review workflow, risk areas, changed-path
  test lookup, testing/docs-impact checks, review checklist.
- `CLAUDE.md` (new): three-line pointer.
- `.github/PULL_REQUEST_TEMPLATE.md` (new): structured template.
- `.github/copilot-instructions.md` (rewritten): 6-line pointer to the
  guides above. All accurate content moves into `AGENTS.md`; inaccurate
  content is dropped.
- `README.md` (drive-by): correct the Python version, extras name, and
  CPU/GPU example lists.

## Tests run

None (docs only). Pre-commit passes.

## Reviewer focus

- `AGENTS.md` "Critical Invariants" — verify the `BaseIntegrationMethod`
  contract description, the `X_<name>` obsm key formula
  (`name = ClassName.replace("Method", "").lower()`), and the CPU/GPU
  extras-to-method mapping match the source.
- `REVIEW_GUIDE.md` "Changed-Path Test Lookup" — confirm the path → test
  mappings reflect the actual `tests/` layout.
